### PR TITLE
fix: tensor changing its assignment to cuda:0 after te functions & sdpa backend conflict

### DIFF
--- a/cosmos_predict2/tokenizers/tokenizer.py
+++ b/cosmos_predict2/tokenizers/tokenizer.py
@@ -220,11 +220,11 @@ class AttentionBlock(nn.Module):
                                                       SDPBackend.EFFICIENT_ATTENTION,
                                                       SDPBackend.CUDNN_ATTENTION,
                                                       SDPBackend.MATH]):
-	     x = F.scaled_dot_product_attention(
-       	     	q,
-             	k,
- 	     	v,
-       	     )
+            x = F.scaled_dot_product_attention(
+                q,
+                k,
+                v,
+            )
         x = x.squeeze(1).permute(0, 2, 1).reshape(b * t, c, h, w)
 
         # output

--- a/cosmos_predict2/tokenizers/tokenizer.py
+++ b/cosmos_predict2/tokenizers/tokenizer.py
@@ -216,11 +216,15 @@ class AttentionBlock(nn.Module):
         q, k, v = self.to_qkv(x).reshape(b * t, 1, c * 3, -1).permute(0, 1, 3, 2).contiguous().chunk(3, dim=-1)
 
         # apply attention
-        x = F.scaled_dot_product_attention(
-            q,
-            k,
-            v,
-        )
+        with sdpa_kernel(backends=[SDPBackend.FLASH_ATTENTION,
+                                                      SDPBackend.EFFICIENT_ATTENTION,
+                                                      SDPBackend.CUDNN_ATTENTION,
+                                                      SDPBackend.MATH]):
+	     x = F.scaled_dot_product_attention(
+       	     	q,
+             	k,
+ 	     	v,
+       	     )
         x = x.squeeze(1).permute(0, 2, 1).reshape(b * t, c, h, w)
 
         # output

--- a/cosmos_predict2/tokenizers/tokenizer.py
+++ b/cosmos_predict2/tokenizers/tokenizer.py
@@ -19,6 +19,7 @@ import torch
 import torch.nn as nn
 import torch.nn.functional as F
 from einops import rearrange
+from torch.nn.attention import SDPBackend, sdpa_kernel
 
 from cosmos_predict2.tokenizers.interface import VideoTokenizerInterface
 from imaginaire.utils import log


### PR DESCRIPTION
When i ran the diffusion with dev-process-batch in predict2 pytriton workflow i was getting errors about `CUDA: Illegal Memory Access `. Output of these Transformer Engine components were always assigned to device cuda:0. I wasn't able to transfer it back to the proper device, due to the same error. The solution with added contexts was proposed by @jkiczka-nvidia  and it seems to work.  